### PR TITLE
spark-connect: add fs.s3.* block mirroring fs.s3a.* (fixes ops#152)

### DIFF
--- a/manifests/spark-connect/base/spark-connect-server.yaml
+++ b/manifests/spark-connect/base/spark-connect-server.yaml
@@ -542,6 +542,21 @@ data:
     spark.hadoop.fs.s3a.change.detection.mode            none
     spark.hadoop.fs.s3a.buffer.dir                       /tmp/spark-local
 
+    # s3:// scheme — routed to S3AFileSystem via fs.s3.impl above; S3AFileSystem
+    # reads config keyed on the URL scheme, so mirror the s3a endpoint / creds
+    # / change-detection settings here. Some UC-registered tables store their
+    # location with scheme s3:// (rather than s3a://); without this block,
+    # those reads fail with `Change detection policy requires ETag` because
+    # MinIO/s3proxy doesn't return ETags.
+    spark.hadoop.fs.s3.endpoint                          http://10.10.0.10:9000
+    spark.hadoop.fs.s3.path.style.access                 true
+    spark.hadoop.fs.s3.connection.ssl.enabled            false
+    spark.hadoop.fs.s3.access.key                        electinfo
+    spark.hadoop.fs.s3.secret.key                        electinfo123
+    spark.hadoop.fs.s3.aws.credentials.provider          org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider
+    spark.hadoop.fs.s3.change.detection.mode             none
+    spark.hadoop.fs.s3.buffer.dir                        /tmp/spark-local
+
     # OpenSearch connection settings
     spark.opensearch.nodes                               opensearch-cluster-aegis.opensearch.svc.cluster.local
     spark.opensearch.port                                9200


### PR DESCRIPTION
## Summary

Unity Catalog stores some table locations with scheme \`s3://\` (rather than \`s3a://\`). S3AFileSystem reads config keyed on the URL scheme — so \`s3://\` reads look at \`fs.s3.*\` keys, not \`fs.s3a.*\`. Only \`fs.s3.impl\` was set (routing the scheme to S3AFileSystem class); all other s3 config (endpoint, creds, change detection) was missing.

Result: reads of \`s3://\`-scheme UC tables fail with

\`\`\`
NoVersionAttributeException: Change detection policy requires ETag
\`\`\`

because the default change-detection mode is strict and MinIO/s3proxy doesn't return ETags.

Surfaced when trying to re-run \`AuditQuicksilverCatalog\` against \`enterprise_fec\` (whose Gold tables are at \`s3://\` locations) after landing the catalog-column compliance fix in electinfo/rundeck#320.

## Fix

Mirror the essential \`fs.s3a.*\` settings under \`fs.s3.*\` in \`spark-connect-server.yaml\` ConfigMap. One block, 9 lines.

## Test plan

- [ ] After merge + ArgoCD sync, restart \`spark-connect-server\` deployment (FS instances cache config at init)
- [ ] Direct read test: \`spark.read.table(\"enterprise_fec.gold.individual_entities\").limit(1).show()\` completes without ETag error
- [ ] Re-run DLT: \`run_pipeline.py --spec pipelines/enterprise_fec/pipeline-quicksilver.yml --refresh <4 entity tables>\` succeeds
- [ ] \`AuditQuicksilverCatalog -catalogs enterprise_fec\` completes (warnings only, no errors)

## Refs

- Fixes electinfo/ops#152
- electinfo/rundeck#320 (catalog column, merged)
- electinfo/rundeck#321 (S3A pipeline config, merged)
- electinfo/enterprise#1760 (UC Quicksilver publisher)
- Linear ELE-2389 (Steve's compliance requirements)